### PR TITLE
Enhance multi-provider model discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
-# Creator and generated projects accept these keys. Only one is required.
+# One or more of these is enough for the creator and generated projects
 OPENAI_API_KEY=
 OPENROUTER_API_KEY=
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+
+# Optional additional providers for discovery (and fallback chat):
+ANTHROPIC_API_KEY=
+GROQ_API_KEY=
+XAI_API_KEY=
+MISTRAL_API_KEY=
+GOOGLE_API_KEY=   # for Gemini model listing (Generative Language API)


### PR DESCRIPTION
## Summary
- replace the creator script to support real-time multi-provider model discovery with scoring, ranking, and interactive overrides
- update the generator templates to persist selected models and configure the generated router with OpenRouter awareness
- refresh the environment example with additional provider keys for discovery

## Testing
- `python -m compileall langgraph_creator.py`


------
https://chatgpt.com/codex/tasks/task_e_68d09539f8ec8328aa18025aecfb12ac